### PR TITLE
Update to logging and fix

### DIFF
--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_btc_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_btc_default_strategy.py
@@ -1,0 +1,171 @@
+import json
+import logging
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+from binance_trade_bot.models import Trade
+from binance_trade_bot.strategies.default_strategy import Strategy
+
+
+class Strategy(Strategy):
+    def initialize(self):
+        super().initialize()
+        self.scount_loop_count = 0
+        self.ha_update_loop_count = 0
+        self.fetch_eur_balance = True
+
+    def scout(self):
+        """
+        Scout for potential jumps from the current coin to another coin
+        """
+        block_print()
+        super().scout()
+        enable_print()
+
+        try:
+            current_coin = self.db.get_current_coin()
+            self.log_scout(current_coin)
+
+            # Update HA sensor AFTER doing the bot functions so that any breakage in HA won't affect trading.
+            # E.g. HA API changes, etc.
+            self.update_ha_sensor(current_coin)
+        except:  # pylint: disable=broad-except
+            self.logger.error("Unexpected Error Updating HA sensor.")
+            # Only log last line as that will fit in Telegram notification perhaps
+            error_last_line = traceback.format_exc().split('\n')[-1]
+            self.logger.error(error_last_line)
+
+    def bridge_scout(self):
+        super().bridge_scout()
+
+    def log_scout(self, current_coin, wait_iterations=600, notification=False):
+        """
+        Log each scout every X times. This will prevent logs getting spammed.
+        """
+
+        if self.scount_loop_count in [0, wait_iterations]:
+            # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
+            # stopped. Don't send to notification service
+            self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=notification)
+            self.scount_loop_count = 0
+        # Log a dot per iteration to show some progress.
+        print(". ", end='\r')
+
+        self.scount_loop_count += 1
+
+    def update_ha_sensor(self, current_coin, wait_iterations=30):
+        """
+        Update the Home Assistant sensor with new data every 30 seconds.
+        """
+        if self.ha_update_loop_count == wait_iterations:
+            self.ha_update_loop_count = 0
+            total_balance_usdt = 0
+            total_coin_in_btc = 0
+            total_balance_eur = 0
+            attributes = {}
+            attributes['bridge'] = self.config.BRIDGE_SYMBOL
+            attributes['current_coin'] = str(current_coin).replace("<", "").replace(">", "")
+            attributes['wallet'] = {}
+
+            for asset in self.manager.binance_client.get_account()["balances"]:
+                if float(asset['free']) > 0:
+                    if asset['asset'] not in ['BUSD', 'USDT']:
+                        current_price = self.manager.get_ticker_price(asset['asset'] + self.config.BRIDGE_SYMBOL)
+                        if isinstance(current_price, float):
+                            asset_value = float(asset['free']) * float(current_price)
+                        else:
+                            self.logger.warning("No price found for current asset={}".format(asset['asset']))
+                            asset_value = 0
+                    else:
+                        asset_value = float(asset['free'])
+
+                    total_balance_usdt += asset_value
+
+                    if asset_value > 1:
+
+                        attributes['wallet'][asset['asset']] = {
+                            'balance': float(asset['free']),
+                            'current_price': float(current_price),
+                            'asset_value_us_dollar': round(asset_value, 2),
+                        }
+
+                        # Get total amount in terms of BTC amount
+                        asset_value_in_btc = self.get_btc_amount(coin_symbol=asset['asset'], coin_total=asset['free'])
+                        total_coin_in_btc += asset_value_in_btc
+                        attributes['wallet'][asset['asset']]['asset_value_in_btc'] = round(asset_value_in_btc, 6)
+
+                        if self.fetch_eur_balance:
+                            # Get total amount in terms of BTC amount
+                            asset_value_in_eur = self.get_btc_amount_in_euro(btc=asset_value_in_btc)
+                            total_balance_eur += asset_value_in_eur
+                            attributes['wallet'][asset['asset']]['asset_value_in_eur'] = round(asset_value_in_eur, 2)
+
+            with self.db.db_session() as session:
+                try:
+                    trade = session.query(Trade).order_by(Trade.datetime.desc()).limit(1).one().info()
+                    if trade:
+                        attributes['last_transaction_attempt'] = datetime.strptime(trade['datetime'],
+                                                                                   "%Y-%m-%dT%H:%M:%S.%f").replace(
+                            tzinfo=timezone.utc).astimezone(tz=None).strftime("%d/%m/%Y %H:%M:%S")
+                except:
+                    pass
+
+            attributes['total_balance_usdt'] = round(total_balance_usdt, 0)
+            attributes['total_balance_eur'] = round(total_balance_eur, 0)
+            attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+            attributes['sensor_update_interval'] = wait_iterations
+            attributes['unit_of_measurement'] = 'BTC'
+            attributes['icon'] = 'mdi:bitcoin'
+            data = {
+                'state': round(total_coin_in_btc, 6),
+                'attributes': attributes
+            }
+            os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
+
+        self.ha_update_loop_count += 1
+
+    def get_btc_amount(self, coin_symbol, coin_total):
+        """
+        Get amount of a coin in BTC terms
+        """
+        btc_coins = 0
+
+        if coin_symbol not in ['BUSD', 'USDT']:
+            # Only check value if not in bridge coin.
+            try:
+                current_coin_price_in_btc = self.manager.get_ticker_price(coin_symbol + "BTC")
+                btc_coins = float(current_coin_price_in_btc) * float(coin_total)
+            except:
+                # Pretty unlikely since all coins trade with BTC
+                self.logger.warning(
+                    "No price found for current coin + BTC={}".format(coin_symbol + "BTC"),
+                    notification=False)
+                pass
+        elif coin_symbol == 'USDT':
+            btc_to_usdt_price = self.manager.get_ticker_price("BTCUSDT")
+            btc_coins = float(coin_total) / float(btc_to_usdt_price)
+
+        return btc_coins
+
+    def get_btc_amount_in_euro(self, btc):
+        """
+        Convert BTC to Euro value
+        """
+        current_coin_price_in_eur = self.manager.get_ticker_price("BTCEUR")
+        return float(current_coin_price_in_eur) * float(btc)
+
+
+def block_print():
+    """
+    Block print command working.
+    """
+    sys.stdout = open(os.devnull, 'w')
+
+
+def enable_print():
+    """
+    Restore print command working.
+    """
+    sys.stdout = sys.__stdout__

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_btc_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_btc_default_strategy.py
@@ -14,8 +14,8 @@ class Strategy(Strategy):
         super().initialize()
         self.scount_loop_count = 0
         self.ha_update_loop_count = 0
-        self.fetch_eur_balance = False
-        self.fetch_usd_balance = True
+        self.fetch_eur_balance = True
+        self.fetch_usd_balance = False
 
     def scout(self):
         """
@@ -116,8 +116,11 @@ class Strategy(Strategy):
                 except:
                     pass
 
-            attributes['total_balance_usdt'] = round(total_balance_usdt, 0)
-            attributes['total_balance_eur'] = round(total_balance_eur, 0)
+            if self.fetch_usd_balance:
+                attributes['total_balance_usdt'] = round(total_balance_usdt, 0)
+            if self.fetch_eur_balance:
+                attributes['total_balance_eur'] = round(total_balance_eur, 0)
+                
             attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
             attributes['sensor_update_interval'] = wait_iterations
             attributes['unit_of_measurement'] = 'BTC'

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -13,6 +13,7 @@ class Strategy(AutoTrader):
         super().initialize()
         self.initialize_current_coin()
         self.scount_loop_count = 0
+        self.ha_update_loop_count = 0
 
     def scout(self):
         """
@@ -83,8 +84,8 @@ class Strategy(AutoTrader):
       """
       Update the Home Assistant sensor with new data every 30 seconds.
       """
-      if self.scount_loop_count == wait_iterations:
-
+      if self.ha_update_loop_count == wait_iterations:
+        self.ha_update_loop_count = 0
         total_balance_usdt = 0
         total_coin_in_btc = 0
         attributes = {}
@@ -137,5 +138,11 @@ class Strategy(AutoTrader):
         attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         attributes['sensor_update_interval'] = wait_iterations
 
-        data = {'state': round(total_coin_in_btc, 4), 'attributes': attributes}
+        data = {
+          'state': round(total_coin_in_btc, 4),
+          'unit_of_measurement': 'BTC',
+          'attributes': attributes
+        }
         os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
+
+      self.ha_update_loop_count += 1

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -20,13 +20,7 @@ class Strategy(AutoTrader):
         """
         current_coin = self.db.get_current_coin()
         
-        if self.scount_loop_count == 60:
-          # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
-          # stopped. Don't send to notification service
-          self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=False)
-          self.scount_loop_count = 0
-
-        self.scount_loop_count += 1
+        self.log_scout(current_coin)
 
         current_coin_price = self.manager.get_ticker_price(current_coin + self.config.BRIDGE)
 
@@ -69,6 +63,19 @@ class Strategy(AutoTrader):
                 self.logger.info(f"Purchasing {current_coin} to begin trading")
                 self.manager.buy_alt(current_coin, self.config.BRIDGE)
                 self.logger.info("Ready to start trading")
+
+    def log_scout(self, current_coin, wait_iterations=60, notification=False):
+      """
+      Log each scout every X times. This will prevent logs getting spammed.
+      """
+
+      if self.scount_loop_count == wait_iterations:
+        # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
+        # stopped. Don't send to notification service
+        self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=notification)
+        self.scount_loop_count = 0
+
+      self.scount_loop_count += 1
 
     def update_ha_sensor(self, current_coin):
       """

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -1,137 +1,101 @@
-import json
-import os
 import random
 import sys
 import time
+import os
+import json
 from datetime import datetime, timezone
 
+from binance_trade_bot.auto_trader import AutoTrader
 from binance_trade_bot.models import Trade
-from binance_trade_bot.strategies.default_strategy import Strategy
 
-
-class Strategy(Strategy):
+class Strategy(AutoTrader):
     def initialize(self):
         super().initialize()
-        self.scount_loop_count = 0
-        self.ha_update_loop_count = 0
+        self.initialize_current_coin()
 
     def scout(self):
         """
         Scout for potential jumps from the current coin to another coin
         """
-        block_print()
-        super().scout()
-        enable_print()
         current_coin = self.db.get_current_coin()
-        self.log_scout(current_coin)
 
-        # Update HA sensor AFTER doing the bot functions so that any breakage in HA won't affect trading.
-        # E.g. HA API changes, etc.
-        self.update_ha_sensor(current_coin)
+        current_coin_price = self.manager.get_ticker_price(current_coin + self.config.BRIDGE)
+
+        if current_coin_price is None:
+            self.logger.info("Skipping scouting... current coin {} not found".format(current_coin + self.config.BRIDGE))
+            return
+
+        # Update Home Assistant sensor
+        total_balance_usdt = 0
+        attributes = {}
+        attributes['bridge'] = self.config.BRIDGE_SYMBOL
+        attributes['current_coin'] = str(current_coin).replace("<", "").replace(">", "")
+        attributes['wallet'] = {}
+
+        for asset in self.manager.binance_client.get_account()["balances"]:
+          if float(asset['free']) > 0:
+            if asset['asset'] not in ['BUSD', 'USDT']:
+              current_price = self.manager.get_ticker_price(asset['asset'] + self.config.BRIDGE_SYMBOL)
+              if isinstance(current_price, float):
+                asset_value = float(asset['free']) * float(current_price)
+              else:
+                self.logger.warning("No price found for current asset={}".format(asset['asset']))
+                asset_value = 0
+            else:
+              asset_value = float(asset['free'])
+
+            total_balance_usdt += asset_value
+
+            if asset_value > 1:
+              attributes['wallet'][asset['asset']] = {'balance': float(asset['free']), 'current_price': float(current_price), 'asset_value': float(asset_value)}
+
+        with self.db.db_session() as session:
+          try:
+            trade = session.query(Trade).order_by(Trade.datetime.desc()).limit(1).one().info()
+            if trade:
+                attributes['last_transaction_attempt'] = datetime.strptime(trade['datetime'], "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc).astimezone(tz=None).strftime("%d/%m/%Y %H:%M:%S")
+          except: 
+            pass
+        
+        attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+
+        data = {'state': round(total_balance_usdt, 2), 'attributes': attributes}
+        os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
+
+        # END - Update Home Assistant sensor
+
+        self._jump_to_best_coin(current_coin, current_coin_price)
+        self.bridge_scout()
 
     def bridge_scout(self):
-        super().bridge_scout()
+        current_coin = self.db.get_current_coin()
+        if self.manager.get_currency_balance(current_coin.symbol) > self.manager.get_min_notional(
+            current_coin.symbol, self.config.BRIDGE.symbol
+        ):
+            # Only scout if we don't have enough of the current coin
+            return
+        new_coin = super().bridge_scout()
+        if new_coin is not None:
+            self.db.set_current_coin(new_coin)
 
-    def log_scout(self, current_coin, wait_iterations=300, notification=False):
+    def initialize_current_coin(self):
         """
-        Log each scout every X times. This will prevent logs getting spammed.
+        Decide what is the current coin, and set it up in the DB.
         """
+        if self.db.get_current_coin() is None:
+            current_coin_symbol = self.config.CURRENT_COIN_SYMBOL
+            if not current_coin_symbol:
+                current_coin_symbol = random.choice(self.config.SUPPORTED_COIN_LIST)
 
-        if self.scount_loop_count in [0, wait_iterations]:
-            # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
-            # stopped. Don't send to notification service
-            self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=notification)
-            self.scount_loop_count = 0
+            self.logger.info(f"Setting initial coin to {current_coin_symbol}")
 
-        self.scount_loop_count += 1
+            if current_coin_symbol not in self.config.SUPPORTED_COIN_LIST:
+                sys.exit("***\nERROR!\nSince there is no backup file, a proper coin name must be provided at init\n***")
+            self.db.set_current_coin(current_coin_symbol)
 
-    def update_ha_sensor(self, current_coin, wait_iterations=30):
-        """
-        Update the Home Assistant sensor with new data every 30 seconds.
-        """
-        if self.ha_update_loop_count == wait_iterations:
-            self.ha_update_loop_count = 0
-            total_balance_usdt = 0
-            total_coin_in_btc = 0
-            attributes = {}
-            attributes['bridge'] = self.config.BRIDGE_SYMBOL
-            attributes['current_coin'] = str(current_coin).replace("<", "").replace(">", "")
-            attributes['wallet'] = {}
-
-            for asset in self.manager.binance_client.get_account()["balances"]:
-                if float(asset['free']) > 0:
-                    if asset['asset'] not in ['BUSD', 'USDT']:
-                        current_price = self.manager.get_ticker_price(asset['asset'] + self.config.BRIDGE_SYMBOL)
-                        if isinstance(current_price, float):
-                            asset_value = float(asset['free']) * float(current_price)
-                        else:
-                            self.logger.warning("No price found for current asset={}".format(asset['asset']))
-                            asset_value = 0
-                    else:
-                        asset_value = float(asset['free'])
-
-                    total_balance_usdt += asset_value
-
-                    if asset_value > 1:
-
-                        # Get total amount in terms of BTC amount
-                        current_coin_btc_asset_value = 0
-
-                        if asset['asset'] not in ['BUSD', 'USDT']:
-                            # Only check value if not in bridge coin.
-                            try:
-                                current_coin_price_in_btc = self.manager.get_ticker_price(current_coin + "BTC")
-                                current_coin_btc_asset_value = float(current_coin_price_in_btc) * float(asset['free'])
-                            except:
-                                # Pretty unlikely since all coins trade with BTC
-                                self.logger.warning(
-                                    "No price found for current coin + BTC={}".format(current_coin + "BTC"),
-                                    notification=False)
-                                pass
-                        elif asset['asset'] == 'USDT':
-                            btc_to_usdt_price = self.manager.get_ticker_price("BTCUSDT")
-                            current_coin_btc_asset_value = float(asset['free']) / float(btc_to_usdt_price)
-
-                        total_coin_in_btc += current_coin_btc_asset_value
-
-                        attributes['wallet'][asset['asset']] = {
-                            'balance': float(asset['free']),
-                            'current_price': float(current_price),
-                            'asset_value_us_dollar': round(asset_value, 2),
-                            'asset_value_in_btc': round(current_coin_btc_asset_value, 6)
-                        }
-
-            with self.db.db_session() as session:
-                try:
-                    trade = session.query(Trade).order_by(Trade.datetime.desc()).limit(1).one().info()
-                    if trade:
-                        attributes['last_transaction_attempt'] = datetime.strptime(trade['datetime'],
-                                                                                   "%Y-%m-%dT%H:%M:%S.%f").replace(
-                            tzinfo=timezone.utc).astimezone(tz=None).strftime("%d/%m/%Y %H:%M:%S")
-                except:
-                    pass
-
-            attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-            attributes['sensor_update_interval'] = wait_iterations
-            attributes['unit_of_measurement'] = 'BTC'
-            data = {
-                'state': round(total_coin_in_btc, 6),
-                'attributes': attributes
-            }
-            os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
-
-        self.ha_update_loop_count += 1
-
-
-def block_print():
-    """
-    Block print command working.
-    """
-    sys.stdout = open(os.devnull, 'w')
-
-
-def enable_print():
-    """
-    Restore print command working.
-    """
-    sys.stdout = sys.__stdout__
+            # if we don't have a configuration, we selected a coin at random... Buy it so we can start trading.
+            if self.config.CURRENT_COIN_SYMBOL == "":
+                current_coin = self.db.get_current_coin()
+                self.logger.info(f"Purchasing {current_coin} to begin trading")
+                self.manager.buy_alt(current_coin, self.config.BRIDGE)
+                self.logger.info("Ready to start trading")

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -12,7 +12,6 @@ from binance_trade_bot.strategies.default_strategy import Strategy
 class Strategy(Strategy):
     def initialize(self):
         super().initialize()
-        self.initialize_current_coin()
         self.scount_loop_count = 0
         self.ha_update_loop_count = 0
 

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -28,8 +28,11 @@ class Strategy(AutoTrader):
             self.logger.info("Skipping scouting... current coin {} not found".format(current_coin + self.config.BRIDGE))
             return
 
-        self.update_ha_sensor(current_coin)
         self._jump_to_best_coin(current_coin, current_coin_price)
+
+        # Update HA sensor AFTER doing the bot functions so that any breakage in HA won't affect trading.
+        # E.g. HA API changes, etc.
+        self.update_ha_sensor(current_coin)
 
     def bridge_scout(self):
         current_coin = self.db.get_current_coin()

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -115,7 +115,8 @@ class Strategy(AutoTrader):
                 current_coin_btc_asset_value = float(current_coin_price_in_btc) * float(asset['free'])
                 total_coin_in_btc += current_coin_btc_asset_value
               except:
-                self.logger.warning("No price found for current coin + BTC={}".format(current_coin + "BTC"))
+                # Pretty unlikely since all coins trade with BTC
+                self.logger.warning("No price found for current coin + BTC={}".format(current_coin + "BTC"), notification=False)
                 pass
                 
               attributes['wallet'][asset['asset']] = {

--- a/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
+++ b/binance-trade-bot-for-hassio/rootfs/_defaults_/binance_trade_bot/strategies/hassio_idkravitz_default_strategy.py
@@ -1,14 +1,15 @@
+import json
+import os
 import random
 import sys
 import time
-import os
-import json
 from datetime import datetime, timezone
 
-from binance_trade_bot.auto_trader import AutoTrader
 from binance_trade_bot.models import Trade
+from binance_trade_bot.strategies.default_strategy import Strategy
 
-class Strategy(AutoTrader):
+
+class Strategy(Strategy):
     def initialize(self):
         super().initialize()
         self.initialize_current_coin()
@@ -19,138 +20,119 @@ class Strategy(AutoTrader):
         """
         Scout for potential jumps from the current coin to another coin
         """
+        block_print()
+        super().scout()
+        enable_print()
         current_coin = self.db.get_current_coin()
-        
-        current_coin_price = self.manager.get_ticker_price(current_coin + self.config.BRIDGE)
-        self.log_scout(current_coin, current_coin_price)
-
-        if current_coin_price is None:
-            self.logger.info("Skipping scouting... current coin {} not found".format(current_coin + self.config.BRIDGE))
-            return
-
-        self._jump_to_best_coin(current_coin, current_coin_price)
+        self.log_scout(current_coin)
 
         # Update HA sensor AFTER doing the bot functions so that any breakage in HA won't affect trading.
         # E.g. HA API changes, etc.
-        self.update_ha_sensor(current_coin, current_coin_price)
+        self.update_ha_sensor(current_coin)
 
     def bridge_scout(self):
-        current_coin = self.db.get_current_coin()
-        if self.manager.get_currency_balance(current_coin.symbol) > self.manager.get_min_notional(
-            current_coin.symbol, self.config.BRIDGE.symbol
-        ):
-            # Only scout if we don't have enough of the current coin
-            return
-        new_coin = super().bridge_scout()
-        if new_coin is not None:
-            self.db.set_current_coin(new_coin)
+        super().bridge_scout()
 
-    def initialize_current_coin(self):
+    def log_scout(self, current_coin, wait_iterations=300, notification=False):
         """
-        Decide what is the current coin, and set it up in the DB.
+        Log each scout every X times. This will prevent logs getting spammed.
         """
-        if self.db.get_current_coin() is None:
-            current_coin_symbol = self.config.CURRENT_COIN_SYMBOL
-            if not current_coin_symbol:
-                current_coin_symbol = random.choice(self.config.SUPPORTED_COIN_LIST)
 
-            self.logger.info(f"Setting initial coin to {current_coin_symbol}")
+        if self.scount_loop_count in [0, wait_iterations]:
+            # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
+            # stopped. Don't send to notification service
+            self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=notification)
+            self.scount_loop_count = 0
 
-            if current_coin_symbol not in self.config.SUPPORTED_COIN_LIST:
-                sys.exit("***\nERROR!\nSince there is no backup file, a proper coin name must be provided at init\n***")
-            self.db.set_current_coin(current_coin_symbol)
+        self.scount_loop_count += 1
 
-            # if we don't have a configuration, we selected a coin at random... Buy it so we can start trading.
-            if self.config.CURRENT_COIN_SYMBOL == "":
-                current_coin = self.db.get_current_coin()
-                self.logger.info(f"Purchasing {current_coin} to begin trading")
-                self.manager.buy_alt(
-                  current_coin, self.config.BRIDGE, self.manager.get_ticker_price(current_coin + self.config.BRIDGE)
-                )
-                self.logger.info("Ready to start trading")
+    def update_ha_sensor(self, current_coin, wait_iterations=30):
+        """
+        Update the Home Assistant sensor with new data every 30 seconds.
+        """
+        if self.ha_update_loop_count == wait_iterations:
+            self.ha_update_loop_count = 0
+            total_balance_usdt = 0
+            total_coin_in_btc = 0
+            attributes = {}
+            attributes['bridge'] = self.config.BRIDGE_SYMBOL
+            attributes['current_coin'] = str(current_coin).replace("<", "").replace(">", "")
+            attributes['wallet'] = {}
 
-    def log_scout(self, current_coin, current_coin_price, wait_iterations=300, notification=False):
-      """
-      Log each scout every X times. This will prevent logs getting spammed.
-      """
+            for asset in self.manager.binance_client.get_account()["balances"]:
+                if float(asset['free']) > 0:
+                    if asset['asset'] not in ['BUSD', 'USDT']:
+                        current_price = self.manager.get_ticker_price(asset['asset'] + self.config.BRIDGE_SYMBOL)
+                        if isinstance(current_price, float):
+                            asset_value = float(asset['free']) * float(current_price)
+                        else:
+                            self.logger.warning("No price found for current asset={}".format(asset['asset']))
+                            asset_value = 0
+                    else:
+                        asset_value = float(asset['free'])
 
-      if self.scount_loop_count in [0, wait_iterations]:
-        # Log the current coin+Bridge, so users can see *some* activity and not think the bot has
-        # stopped. Don't send to notification service
-        self.logger.info(f"Scouting... current: {current_coin + self.config.BRIDGE}", notification=notification)
-        self.scount_loop_count = 0
+                    total_balance_usdt += asset_value
 
-      self.scount_loop_count += 1
+                    if asset_value > 1:
 
-    def update_ha_sensor(self, current_coin, current_coin_price, wait_iterations=30):
-      """
-      Update the Home Assistant sensor with new data every 30 seconds.
-      """
-      if self.ha_update_loop_count == wait_iterations:
-        self.ha_update_loop_count = 0
-        total_balance_usdt = 0
-        total_coin_in_btc = 0
-        attributes = {}
-        attributes['bridge'] = self.config.BRIDGE_SYMBOL
-        attributes['current_coin'] = str(current_coin).replace("<", "").replace(">", "")
-        attributes['wallet'] = {}
+                        # Get total amount in terms of BTC amount
+                        current_coin_btc_asset_value = 0
 
-        for asset in self.manager.binance_client.get_account()["balances"]:
-          if float(asset['free']) > 0:
-            if asset['asset'] not in ['BUSD', 'USDT']:
-              current_price = self.manager.get_ticker_price(asset['asset'] + self.config.BRIDGE_SYMBOL)
-              if isinstance(current_price, float):
-                asset_value = float(asset['free']) * float(current_price)
-              else:
-                self.logger.warning("No price found for current asset={}".format(asset['asset']))
-                asset_value = 0
-            else:
-              asset_value = float(asset['free'])
+                        if asset['asset'] not in ['BUSD', 'USDT']:
+                            # Only check value if not in bridge coin.
+                            try:
+                                current_coin_price_in_btc = self.manager.get_ticker_price(current_coin + "BTC")
+                                current_coin_btc_asset_value = float(current_coin_price_in_btc) * float(asset['free'])
+                            except:
+                                # Pretty unlikely since all coins trade with BTC
+                                self.logger.warning(
+                                    "No price found for current coin + BTC={}".format(current_coin + "BTC"),
+                                    notification=False)
+                                pass
+                        elif asset['asset'] == 'USDT':
+                            btc_to_usdt_price = self.manager.get_ticker_price("BTCUSDT")
+                            current_coin_btc_asset_value = float(asset['free']) / float(btc_to_usdt_price)
 
-            total_balance_usdt += asset_value
+                        total_coin_in_btc += current_coin_btc_asset_value
 
-            if asset_value > 1:
+                        attributes['wallet'][asset['asset']] = {
+                            'balance': float(asset['free']),
+                            'current_price': float(current_price),
+                            'asset_value_us_dollar': round(asset_value, 2),
+                            'asset_value_in_btc': round(current_coin_btc_asset_value, 6)
+                        }
 
-              # Get total amount in terms of BTC amount
-              current_coin_btc_asset_value = 0
-
-              if asset['asset'] not in ['BUSD', 'USDT']:
-                # Only check value if not in bridge coin.
+            with self.db.db_session() as session:
                 try:
-                  current_coin_price_in_btc = self.manager.get_ticker_price(current_coin + "BTC")
-                  current_coin_btc_asset_value = float(current_coin_price_in_btc) * float(asset['free'])
+                    trade = session.query(Trade).order_by(Trade.datetime.desc()).limit(1).one().info()
+                    if trade:
+                        attributes['last_transaction_attempt'] = datetime.strptime(trade['datetime'],
+                                                                                   "%Y-%m-%dT%H:%M:%S.%f").replace(
+                            tzinfo=timezone.utc).astimezone(tz=None).strftime("%d/%m/%Y %H:%M:%S")
                 except:
-                  # Pretty unlikely since all coins trade with BTC
-                  self.logger.warning("No price found for current coin + BTC={}".format(current_coin + "BTC"), notification=False)
-                  pass
-              elif asset['asset'] == 'USDT':
-                btc_to_usdt_price = self.manager.get_ticker_price("BTCUSDT")
-                current_coin_btc_asset_value = float(asset['free']) / float(btc_to_usdt_price)
-                
-              total_coin_in_btc += current_coin_btc_asset_value
+                    pass
 
-              attributes['wallet'][asset['asset']] = {
-                'balance': float(asset['free']), 
-                'current_price': float(current_price), 
-                'asset_value_us_dollar': round(asset_value, 2),
-                'asset_value_in_btc': round(current_coin_btc_asset_value, 6)
-              }
+            attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+            attributes['sensor_update_interval'] = wait_iterations
+            attributes['unit_of_measurement'] = 'BTC'
+            data = {
+                'state': round(total_coin_in_btc, 6),
+                'attributes': attributes
+            }
+            os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
 
-        with self.db.db_session() as session:
-          try:
-            trade = session.query(Trade).order_by(Trade.datetime.desc()).limit(1).one().info()
-            if trade:
-                attributes['last_transaction_attempt'] = datetime.strptime(trade['datetime'], "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc).astimezone(tz=None).strftime("%d/%m/%Y %H:%M:%S")
-          except: 
-            pass
-        
-        attributes['last_sensor_update'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-        attributes['sensor_update_interval'] = wait_iterations
-        attributes['unit_of_measurement'] = 'BTC'
-        data = {
-          'state': round(total_coin_in_btc, 6),
-          'attributes': attributes
-        }
-        os.system("/scripts/update_ha_sensor.sh '" + str(json.dumps(data)) + "'")
+        self.ha_update_loop_count += 1
 
-      self.ha_update_loop_count += 1
+
+def block_print():
+    """
+    Block print command working.
+    """
+    sys.stdout = open(os.devnull, 'w')
+
+
+def enable_print():
+    """
+    Restore print command working.
+    """
+    sys.stdout = sys.__stdout__

--- a/binance-trade-bot-for-hassio/rootfs/scripts/update_ha_sensor.sh
+++ b/binance-trade-bot-for-hassio/rootfs/scripts/update_ha_sensor.sh
@@ -26,6 +26,6 @@ bashio::log.debug "API Response: ${response}"
 if [[ "${status}" -eq 200 || "${status}" -eq 201 ]]; then
     bashio::log.debug "${status} ${response}"
 else
-    bashio::log.error "${status} ${response}"
+    bashio::log.error "Could not update HA Sensor. ${status} ${response}"
     exit ${status}
 fi


### PR DESCRIPTION
* Refactor HA stuff into own function
* Remove call to `self.bridge_scout()` as that is not in original default by idkratviz [here](https://github.com/idkravitz/binance-trade-bot/blob/master/binance_trade_bot/strategies/default_strategy.py)
* Update HA sensor AFTER doing the bot functions so that any breakage in HA won't affect trading.  E.g. HA API changes, etc.

* Add logging for every 60 scouts. 
* Instead of using print for that, use logger with notification set to False so Telegram wont get it.

<img width="1407" alt="Screenshot 2021-05-19 at 09 38 38" src="https://user-images.githubusercontent.com/254309/118782871-70a63000-b886-11eb-8394-6b132e3b9ab3.png">

* Also when updating the sensor. HA proxy will return 502 when Home Assistant is restarting due to upgrade or any other reason. Add extra log so we know in logs what happened. Right now it just shows this:

![image](https://user-images.githubusercontent.com/254309/118799622-d8647700-b896-11eb-9aa7-c097c6821780.png)

* Also, set sensor state to be the value of holdings in terms of BTC, which, in my opinion is more valuable then the FIAT value.
* Also only push to HA every 30 scouts, since pushing every 1 can be a bit much with a 1 second scout time. I find this can lock up my HA UI.
